### PR TITLE
 changed catsareawesomeXXX to catsareawesome123

### DIFF
--- a/lab_files/01_aws_sa_fundamentals/getting_started_with_cfn/updatestack2.json
+++ b/lab_files/01_aws_sa_fundamentals/getting_started_with_cfn/updatestack2.json
@@ -3,7 +3,7 @@
     "catpics" : {
       "Type" : "AWS::S3::Bucket",
       "Properties" : {
-        "BucketName" : "catsareawesomeXXX"
+        "BucketName" : "catsareawesome123"
       }
     },
     "dogpics" : {


### PR DESCRIPTION
I kept getting the "Bucket name should not contain uppercase characters" error when applying this update. I made this change and it works fine now.