### PR TITLE
Clarified purpose of text boxes and use placeholder secondsToWait if value is empty

### DIFF
--- a/lab_files/03_compute/serverless_reminder_app/static_website/formlogic.js
+++ b/lab_files/03_compute/serverless_reminder_app/static_website/formlogic.js
@@ -10,7 +10,12 @@ var successDiv = document.getElementById('success-message')
 var resultsDiv = document.getElementById('results-message')
 
 // Setup easy way to reference values of the input boxes
-function waitSecondsValue() { return document.getElementById('waitSeconds').value }
+function waitSecondsValue() { 
+    if (document.getElementById('waitSeconds').value == "") {
+        return document.getElementById('waitSeconds').placeholder
+    }
+    else return document.getElementById('waitSeconds').value
+}
 function messageValue() { return document.getElementById('message').value }
 function emailValue() { return document.getElementById('email').value }
 function phoneValue() { return document.getElementById('phone').value }

--- a/lab_files/03_compute/serverless_reminder_app/static_website/index.html
+++ b/lab_files/03_compute/serverless_reminder_app/static_website/index.html
@@ -31,13 +31,17 @@
         <div id='success-message'></div>
         <label for="waitSeconds" class="sr-only"></label>
         <p>Required sections:</p>
-        <input type="text" id="waitSeconds" class="form-control" placeholder="Seconds to wait... e.g. 10">
+        Seconds to Wait
+        <input type="text" id="waitSeconds" class="form-control" placeholder="10">
+        Message
         <label for="message" class="sr-only">Message (Required)</label>
         <input type="text" id="message" class="form-control" placeholder="Message (Required)">
         <hr>
         <p>Email address is required for email reminders, phone number is required for phone reminders:</p>
         <label for="email" class="sr-only">email</label>
+        Email:
         <input type="email" id="email" class="form-control" placeholder="someone@something.com">
+        Phone Number
         <label for="phone" class="sr-only">phone</label>
         <input type="text" id="phone" class="form-control" placeholder="+15556667788">
         <hr>


### PR DESCRIPTION
This fix makes the webpage more readable by having headings above each text box and not relying on placeholders.
It also replaces the placeholder for seconds to wait with just numbers, and 


* will now grab the placeholder value for seconds to wait if it has not been completed by student 

Related Asana Task: https://app.asana.com/0/1135892860243873/1198888586209615/f
